### PR TITLE
Added test for the CleanCommand. (#405)

### DIFF
--- a/Tests/Command/CleanCommandTest.php
+++ b/Tests/Command/CleanCommandTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the FOSOAuthServerBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\OAuthServerBundle\Tests\Command;
+
+use FOS\OAuthServerBundle\Command\CleanCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\Container;
+
+class CleanCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CleanCommand
+     */
+    private $command;
+
+    /**
+     * @var Container
+     */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $command = new CleanCommand();
+
+        $application = new Application();
+        $application->add($command);
+
+        $this->container = new Container();
+
+        $this->command = $application->find($command->getName());
+        $this->command->setContainer($this->container);
+    }
+
+    /**
+     * Delete expired tokens for provided classes.
+     *
+     * @dataProvider classProvider
+     *
+     * @param string $class A fully qualified class name.
+     */
+    public function testItShouldRemoveExpiredToken($class)
+    {
+        $expiredAccessTokens = 5;
+        $accessTokenManager = $this->getMock($class);
+        $accessTokenManager
+            ->expects($this->once())
+            ->method('deleteExpired')
+            ->will($this->returnValue($expiredAccessTokens));
+
+        $expiredRefreshTokens = 183;
+        $refreshTokenManager = $this->getMock($class);
+        $refreshTokenManager
+            ->expects($this->once())
+            ->method('deleteExpired')
+            ->will($this->returnValue($expiredRefreshTokens));
+
+        $expiredAuthCodes = 0;
+        $authCodeManager = $this->getMock($class);
+        $authCodeManager
+            ->expects($this->once())
+            ->method('deleteExpired')
+            ->will($this->returnValue($expiredAuthCodes));
+
+        $this->container->set('fos_oauth_server.access_token_manager', $accessTokenManager);
+        $this->container->set('fos_oauth_server.refresh_token_manager', $refreshTokenManager);
+        $this->container->set('fos_oauth_server.auth_code_manager', $authCodeManager);
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(array('command' => $this->command->getName()));
+
+        $display = $tester->getDisplay();
+
+        $this->assertContains(sprintf('Removed %d items from %s storage.', $expiredAccessTokens, 'Access token'), $display);
+        $this->assertContains(sprintf('Removed %d items from %s storage.', $expiredRefreshTokens, 'Refresh token'), $display);
+        $this->assertContains(sprintf('Removed %d items from %s storage.', $expiredAuthCodes, 'Auth code'), $display);
+    }
+
+    /**
+     * Skip classes for deleting expired tokens that do not implement AuthCodeManagerInterface or TokenManagerInterface.
+     */
+    public function testItShouldNotRemoveExpiredTokensForOtherClasses()
+    {
+        $this->container->set('fos_oauth_server.access_token_manager', new \stdClass());
+        $this->container->set('fos_oauth_server.refresh_token_manager', new \stdClass());
+        $this->container->set('fos_oauth_server.auth_code_manager', new \stdClass());
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(array('command' => $this->command->getName()));
+
+        $display = $tester->getDisplay();
+
+        $this->assertNotRegExp(sprintf('\'Removed (\d)+ items from %s storage.\'', 'Access token'), $display);
+        $this->assertNotRegExp(sprintf('\'Removed (\d)+ items from %s storage.\'', 'Refresh token'), $display);
+        $this->assertNotRegExp(sprintf('\'Removed (\d)+ items from %s storage.\'', 'Auth code'), $display);
+    }
+
+    /**
+     * Provides the classes that should be accepted by the CleanCommand.
+     *
+     * @return array[]
+     */
+    public function classProvider()
+    {
+        return array(
+            array('FOS\OAuthServerBundle\Model\TokenManagerInterface'),
+            array('FOS\OAuthServerBundle\Model\AuthCodeManagerInterface'),
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,14 @@
         "php": "^5.3.3|^7.0",
         "friendsofsymfony/oauth2-php": "~1.1",
         "symfony/framework-bundle": "~2.2|~3.0",
-        "symfony/security-bundle": "~2.1|~3.0"
+        "symfony/security-bundle": "~2.1|~3.0",
+        "symfony/dependency-injection": "^2.0.5|~3.0"
     },
     "require-dev": {
         "symfony/class-loader": "~2.1|~3.0",
         "symfony/yaml": "~2.1|~3.0",
         "symfony/form": "~2.3|~3.0",
+        "symfony/console": "~2.1|~3.0",
         "willdurand/propel-typehintable-behavior": "^1.0.4",
         "propel/propel1": "^1.6.5",
         "phing/phing": "~2.4",
@@ -37,7 +39,8 @@
         "doctrine/mongodb-odm-bundle": "*",
         "propel/propel-bundle": "If you want to use Propel with Symfony2, then you will have to install the PropelBundle",
         "willdurand/propel-typehintable-behavior": "The Typehintable behavior is useful to add type hints on generated methods, to be compliant with interfaces",
-        "symfony/form" : "Needed to be able to use the AuthorizeFormType"
+        "symfony/form" : "Needed to be able to use the AuthorizeFormType",
+        "symfony/console": "Needed to be able to use commands"
     },
     "autoload": {
         "psr-4": { "FOS\\OAuthServerBundle\\": "" }
@@ -47,5 +50,4 @@
             "dev-master": "1.5-dev"
         }
     }
-
 }


### PR DESCRIPTION
* Added test for the CleanCommand.
Added "symfony/console" to dev dependencies and suggestions to be able to use and test it.
Removed superfluous blank line.

* Added minimum version for "symfony/dependency-injection" where auto loading was introduced for composer.json.

* Refactored the CleanCommandTest based on feedback.
 * Changed container from a mock to the real object.
 * Changed the two separate interface tests to be provided to one new test.
 * Removed unnecessary use of regular expressions to test output.